### PR TITLE
Corrected conversion of Char Array to String

### DIFF
--- a/Exosite.cpp
+++ b/Exosite.cpp
@@ -197,7 +197,7 @@ boolean Exosite::writeRead(String writeString, String readString, String &return
   readString.toCharArray(readCharString, readString.length()+1);
 
   if(this->writeRead(writeCharString, readCharString, &returnCharString)){
-    returnString = returnCharString;
+    returnString = String(returnCharString);
     ret = true;
   }else{
     Serial.println(F("Error Communicating with Exosite"));


### PR DESCRIPTION
My sketches were randomly crashing and would reset during my writeRead() call; I traced it to this line, and this change fixed the problem.
